### PR TITLE
[기능] 꿈 도메인 생성 관련 테스트 및 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.4'
     id 'io.spring.dependency-management' version '1.1.4'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'org.example'
@@ -15,6 +16,8 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -35,6 +38,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // query dsl
+    implementation "com.querydsl:querydsl-jpa"
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // log
     implementation "dev.akkinoc.spring.boot:logback-access-spring-boot-starter:$log_back_access_version"
@@ -67,4 +78,20 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Qtype 생성 경로
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/org/example/kkumdoriland/auth/config/WebSecurityConfig.java
+++ b/src/main/java/org/example/kkumdoriland/auth/config/WebSecurityConfig.java
@@ -31,7 +31,7 @@ public class WebSecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        final AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
         authenticationManagerBuilder.authenticationProvider(restAuthenticationProvider);
         AuthenticationManager authenticationManager = authenticationManagerBuilder.build();
 
@@ -43,6 +43,7 @@ public class WebSecurityConfig {
             )
             .authenticationManager(authenticationManager)
             .addFilterBefore(restAuthenticationFilter(http, authenticationManager), UsernamePasswordAuthenticationFilter.class)
+            .sessionManagement(sessionManagement -> sessionManagement.maximumSessions(3).maxSessionsPreventsLogin(true))
             .exceptionHandling(exception -> exception.authenticationEntryPoint(restAuthenticationEntryPoint).accessDeniedHandler(restAccessDeniedHandler))
             .csrf(AbstractHttpConfigurer::disable)
         ;

--- a/src/main/java/org/example/kkumdoriland/auth/config/WebSecurityConfig.java
+++ b/src/main/java/org/example/kkumdoriland/auth/config/WebSecurityConfig.java
@@ -2,6 +2,8 @@ package org.example.kkumdoriland.auth.config;
 
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.auth.filter.RestAuthenticationFilter;
+import org.example.kkumdoriland.auth.handler.RestAccessDeniedHandler;
+import org.example.kkumdoriland.auth.handler.RestAuthenticationEntryPoint;
 import org.example.kkumdoriland.auth.handler.RestAuthenticationFailureHandler;
 import org.example.kkumdoriland.auth.handler.RestAuthenticationSuccessHandler;
 import org.example.kkumdoriland.auth.provider.RestAuthenticationProvider;
@@ -24,6 +26,8 @@ public class WebSecurityConfig {
     private final RestAuthenticationProvider restAuthenticationProvider;
     private final RestAuthenticationSuccessHandler restAuthenticationSuccessHandler;
     private final RestAuthenticationFailureHandler restAuthenticationFailureHandler;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -39,6 +43,7 @@ public class WebSecurityConfig {
             )
             .authenticationManager(authenticationManager)
             .addFilterBefore(restAuthenticationFilter(http, authenticationManager), UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exception -> exception.authenticationEntryPoint(restAuthenticationEntryPoint).accessDeniedHandler(restAccessDeniedHandler))
             .csrf(AbstractHttpConfigurer::disable)
         ;
         

--- a/src/main/java/org/example/kkumdoriland/auth/handler/RestAccessDeniedHandler.java
+++ b/src/main/java/org/example/kkumdoriland/auth/handler/RestAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package org.example.kkumdoriland.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.getWriter().write(mapper.writeValueAsString(HttpServletResponse.SC_FORBIDDEN));
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/auth/handler/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/kkumdoriland/auth/handler/RestAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package org.example.kkumdoriland.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(mapper.writeValueAsString(HttpServletResponse.SC_UNAUTHORIZED));
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/auth/handler/RestAuthenticationSuccessHandler.java
+++ b/src/main/java/org/example/kkumdoriland/auth/handler/RestAuthenticationSuccessHandler.java
@@ -5,7 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.example.kkumdoriland.member.dto.MemberDTO;
+import org.example.kkumdoriland.auth.dto.AuthContext;
 import org.example.kkumdoriland.member.dto.MemberResponse;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -22,8 +22,8 @@ public class RestAuthenticationSuccessHandler implements AuthenticationSuccessHa
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        final MemberDTO memberDTO = (MemberDTO) authentication.getPrincipal();
-        final MemberResponse memberResponse = new MemberResponse(memberDTO.getId(), memberDTO.getName());
+        final AuthContext authContext = (AuthContext) authentication.getPrincipal();
+        final MemberResponse memberResponse = new MemberResponse(authContext.getMemberDTO().getId(), authContext.getMemberDTO().getName());
 
         mapper.writeValue(response.getWriter(), memberResponse);
     }

--- a/src/main/java/org/example/kkumdoriland/auth/provider/RestAuthenticationProvider.java
+++ b/src/main/java/org/example/kkumdoriland/auth/provider/RestAuthenticationProvider.java
@@ -34,7 +34,7 @@ public class RestAuthenticationProvider implements AuthenticationProvider {
         final MemberDTO memberDTO = authContext.getMemberDTO();
         memberDTO.clearPassword();
 
-        return new RestAuthenticationToken(memberDTO, null, authContext.getAuthorities());
+        return new RestAuthenticationToken(authContext, null, authContext.getAuthorities());
     }
 
     @Override

--- a/src/main/java/org/example/kkumdoriland/auth/token/RestAuthenticationToken.java
+++ b/src/main/java/org/example/kkumdoriland/auth/token/RestAuthenticationToken.java
@@ -12,12 +12,14 @@ public class RestAuthenticationToken extends AbstractAuthenticationToken {
         super(null);
         this.principal = principal;
         this.credentials = credentials;
+        setAuthenticated(false);
     }
 
     public RestAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.principal = principal;
         this.credentials = credentials;
+        setAuthenticated(true);
     }
 
     @Override

--- a/src/main/java/org/example/kkumdoriland/common/domain/BaseEntity.java
+++ b/src/main/java/org/example/kkumdoriland/common/domain/BaseEntity.java
@@ -3,10 +3,12 @@ package org.example.kkumdoriland.common.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 @MappedSuperclass
+@Getter
 public class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/org/example/kkumdoriland/dream/domain/DailyHistory.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/DailyHistory.java
@@ -1,4 +1,4 @@
-package org.example.kkumdoriland.dream;
+package org.example.kkumdoriland.dream.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -7,23 +7,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import org.example.kkumdoriland.common.domain.BaseEntity;
-import org.example.kkumdoriland.member.domain.Member;
 
 @Entity
-public class Dream extends BaseEntity {
+public class DailyHistory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
-
     @Column(columnDefinition = "text")
-    private String description;
-    private LocalDateTime dueDate;
+    private String contentText;
+    private int stepSize;
 
     @ManyToOne
-    @JoinColumn(name="ownerId")
-    private Member user;
+    @JoinColumn(name="mileStoneId")
+    private MileStone mileStone;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/DailyHistory.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/DailyHistory.java
@@ -8,9 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.kkumdoriland.common.domain.BaseEntity;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class DailyHistory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,4 +27,10 @@ public class DailyHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="mileStoneId")
     private MileStone mileStone;
+
+    public DailyHistory(String contentText, int stepSize, MileStone mileStone) {
+        this.contentText = contentText;
+        this.stepSize = stepSize;
+        this.mileStone = mileStone;
+    }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/DailyHistory.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/DailyHistory.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.dream.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,7 +20,7 @@ public class DailyHistory extends BaseEntity {
     private String contentText;
     private int stepSize;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="mileStoneId")
     private MileStone mileStone;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
@@ -8,7 +8,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,4 +38,11 @@ public class Dream extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="ownerId")
     private Member user;
+
+    @OneToMany(mappedBy = "dream")
+    private List<MileStone> mileStones = new ArrayList<>();
+
+    public boolean isOwner(long memberId) {
+        return user.getId().equals(memberId);
+    }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.dream.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +32,7 @@ public class Dream extends BaseEntity {
     private String description;
     private LocalDateTime dueDate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="ownerId")
     private Member user;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
@@ -8,10 +8,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.kkumdoriland.common.domain.BaseEntity;
 import org.example.kkumdoriland.member.domain.Member;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Dream extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/Dream.java
@@ -1,4 +1,4 @@
-package org.example.kkumdoriland.dream;
+package org.example.kkumdoriland.dream.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -7,19 +7,23 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import org.example.kkumdoriland.common.domain.BaseEntity;
+import org.example.kkumdoriland.member.domain.Member;
 
 @Entity
-public class DailyHistory extends BaseEntity {
+public class Dream extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String title;
+
     @Column(columnDefinition = "text")
-    private String contentText;
-    private int stepSize;
+    private String description;
+    private LocalDateTime dueDate;
 
     @ManyToOne
-    @JoinColumn(name="mileStoneId")
-    private MileStone mileStone;
+    @JoinColumn(name="ownerId")
+    private Member user;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +17,8 @@ import org.example.kkumdoriland.common.domain.BaseEntity;
 
 @Entity
 @Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 public class MileStone extends BaseEntity {
     @Id

--- a/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
@@ -8,9 +8,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.kkumdoriland.common.domain.BaseEntity;
 
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public class MileStone extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
@@ -1,4 +1,4 @@
-package org.example.kkumdoriland.dream;
+package org.example.kkumdoriland.dream.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
@@ -36,4 +36,8 @@ public class MileStone extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="dreamId")
     private Dream dream;
+
+    public boolean isOwner(long memberId) {
+        return dream.isOwner(memberId);
+    }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
+++ b/src/main/java/org/example/kkumdoriland/dream/domain/MileStone.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.dream.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +24,7 @@ public class MileStone extends BaseEntity {
     private int totalScoreToEarn;
     private int minimumStepSize;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="dreamId")
     private Dream dream;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryCreateDTO.java
@@ -1,0 +1,24 @@
+package org.example.kkumdoriland.dream.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.kkumdoriland.dream.domain.DailyHistory;
+import org.example.kkumdoriland.dream.domain.MileStone;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class DailyHistoryCreateDTO {
+    @NotNull
+    private String contentText;
+
+    @NotNull
+    private Integer stepSize;
+
+    @NotNull
+    private Long mileStoneId;
+
+    public static DailyHistory toDailyHistory(DailyHistoryCreateDTO dto, MileStone mileStone) {
+        return new DailyHistory(dto.getContentText(), dto.getStepSize(), mileStone);
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryCreateDTO.java
@@ -2,11 +2,13 @@ package org.example.kkumdoriland.dream.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.kkumdoriland.dream.domain.DailyHistory;
 import org.example.kkumdoriland.dream.domain.MileStone;
 import org.jetbrains.annotations.NotNull;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class DailyHistoryCreateDTO {
     @NotNull

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryCreateDTO.java
@@ -20,7 +20,7 @@ public class DailyHistoryCreateDTO {
     @NotNull
     private Long mileStoneId;
 
-    public static DailyHistory toDailyHistory(DailyHistoryCreateDTO dto, MileStone mileStone) {
-        return new DailyHistory(dto.getContentText(), dto.getStepSize(), mileStone);
+    public DailyHistory toDailyHistory(MileStone mileStone) {
+        return new DailyHistory(contentText, stepSize, mileStone);
     }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryResponse.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DailyHistoryResponse.java
@@ -1,0 +1,29 @@
+package org.example.kkumdoriland.dream.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.example.kkumdoriland.dream.domain.DailyHistory;
+
+@Getter
+public class DailyHistoryResponse {
+
+    private Long id;
+
+    private String contentText;
+    private Integer stepSize;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static DailyHistoryResponse of(DailyHistory dailyHistory) {
+        final DailyHistoryResponse response = new DailyHistoryResponse();
+
+        response.id = dailyHistory.getId();
+        response.contentText = dailyHistory.getContentText();
+        response.stepSize = dailyHistory.getStepSize();
+        response.createdAt = dailyHistory.getCreatedAt();
+        response.updatedAt = dailyHistory.getUpdatedAt();
+
+        return response;
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DreamCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DreamCreateDTO.java
@@ -1,0 +1,16 @@
+package org.example.kkumdoriland.dream.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+@RequiredArgsConstructor
+public class DreamCreateDTO {
+    @NotNull
+    private final String title;
+    @NotNull
+    private final String description;
+    @NotNull
+    private final String dueDate;
+}

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DreamCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DreamCreateDTO.java
@@ -3,14 +3,18 @@ package org.example.kkumdoriland.dream.dto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @RequiredArgsConstructor
 public class DreamCreateDTO {
     @NotNull
     private final String title;
+
     @NotNull
     private final String description;
+
     @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private final String dueDate;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DreamCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DreamCreateDTO.java
@@ -1,20 +1,22 @@
 package org.example.kkumdoriland.dream.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 public class DreamCreateDTO {
     @NotNull
-    private final String title;
+    private String title;
 
     @NotNull
-    private final String description;
+    private String description;
 
     @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private final String dueDate;
+    private String dueDate;
 }

--- a/src/main/java/org/example/kkumdoriland/dream/dto/DreamResponse.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/DreamResponse.java
@@ -1,0 +1,26 @@
+package org.example.kkumdoriland.dream.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.example.kkumdoriland.dream.domain.Dream;
+
+@Getter
+public class DreamResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private LocalDateTime dueDate;
+    private Long ownerId;
+
+    public static DreamResponse of(Dream savedDream) {
+        final DreamResponse response = new DreamResponse();
+
+        response.id = savedDream.getId();
+        response.title = savedDream.getTitle();
+        response.description = savedDream.getDescription();
+        response.dueDate = savedDream.getDueDate();
+        response.ownerId = savedDream.getUser().getId();
+
+        return response;
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/dream/dto/MileStoneCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/MileStoneCreateDTO.java
@@ -1,0 +1,17 @@
+package org.example.kkumdoriland.dream.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class MileStoneCreateDTO {
+    private Long dreamId;
+    @NotNull
+    private String title;
+    @NotNull
+    private String description;
+    private int totalScoreToEarn;
+    private int minimumStepSize;
+}

--- a/src/main/java/org/example/kkumdoriland/dream/dto/MileStoneCreateDTO.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/MileStoneCreateDTO.java
@@ -2,9 +2,11 @@ package org.example.kkumdoriland.dream.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class MileStoneCreateDTO {
     private Long dreamId;

--- a/src/main/java/org/example/kkumdoriland/dream/dto/MileStoneResponse.java
+++ b/src/main/java/org/example/kkumdoriland/dream/dto/MileStoneResponse.java
@@ -1,0 +1,27 @@
+package org.example.kkumdoriland.dream.dto;
+
+import lombok.Getter;
+import org.example.kkumdoriland.dream.domain.MileStone;
+
+@Getter
+public class MileStoneResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private boolean achieved;
+    private int totalScoreToEarn;
+    private int minimumStepSize;
+
+    public static MileStoneResponse of(MileStone mileStone) {
+        MileStoneResponse response = new MileStoneResponse();
+
+        response.id = mileStone.getId();
+        response.title = mileStone.getTitle();
+        response.description = mileStone.getDescription();
+        response.achieved = mileStone.isAchieved();
+        response.totalScoreToEarn = mileStone.getTotalScoreToEarn();
+        response.minimumStepSize = mileStone.getMinimumStepSize();
+
+        return response;
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/dream/repository/DailyHistoryRepository.java
+++ b/src/main/java/org/example/kkumdoriland/dream/repository/DailyHistoryRepository.java
@@ -1,0 +1,8 @@
+package org.example.kkumdoriland.dream.repository;
+
+import org.example.kkumdoriland.dream.domain.DailyHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyHistoryRepository extends JpaRepository<DailyHistory, Long> {
+
+}

--- a/src/main/java/org/example/kkumdoriland/dream/repository/DreamRepository.java
+++ b/src/main/java/org/example/kkumdoriland/dream/repository/DreamRepository.java
@@ -1,0 +1,9 @@
+package org.example.kkumdoriland.dream.repository;
+
+import java.util.Optional;
+import org.example.kkumdoriland.dream.domain.Dream;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DreamRepository extends JpaRepository<Dream, Long> {
+    Optional<Dream> findDreamByTitle(String title);
+}

--- a/src/main/java/org/example/kkumdoriland/dream/repository/DreamRepository.java
+++ b/src/main/java/org/example/kkumdoriland/dream/repository/DreamRepository.java
@@ -1,9 +1,12 @@
 package org.example.kkumdoriland.dream.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.example.kkumdoriland.dream.domain.Dream;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DreamRepository extends JpaRepository<Dream, Long> {
     Optional<Dream> findDreamByTitle(String title);
+
+    List<Dream> findDreamsByUserId(Long userId);
 }

--- a/src/main/java/org/example/kkumdoriland/dream/repository/MileStoneRepository.java
+++ b/src/main/java/org/example/kkumdoriland/dream/repository/MileStoneRepository.java
@@ -1,0 +1,8 @@
+package org.example.kkumdoriland.dream.repository;
+
+import org.example.kkumdoriland.dream.domain.MileStone;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MileStoneRepository extends JpaRepository<MileStone, Long> {
+
+}

--- a/src/main/java/org/example/kkumdoriland/dream/service/DailyHistoryService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DailyHistoryService.java
@@ -1,0 +1,33 @@
+package org.example.kkumdoriland.dream.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.kkumdoriland.dream.domain.DailyHistory;
+import org.example.kkumdoriland.dream.domain.MileStone;
+import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
+import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
+import org.example.kkumdoriland.dream.repository.DailyHistoryRepository;
+import org.example.kkumdoriland.dream.repository.MileStoneRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DailyHistoryService {
+    private final MileStoneRepository mileStoneRepository;
+    private final DailyHistoryRepository dailyHistoryRepository;
+
+    @Transactional
+    public DailyHistoryResponse createDailyHistory(Long memberId, DailyHistoryCreateDTO dto) {
+        final MileStone mileStone = mileStoneRepository.getReferenceById(dto.getMileStoneId());
+
+        if (!mileStone.getDream().getUser().getId().equals(memberId)) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        final DailyHistory dailyHistory = DailyHistoryCreateDTO.toDailyHistory(dto, mileStone);
+        dailyHistoryRepository.save(dailyHistory);
+
+        return DailyHistoryResponse.of(dailyHistory);
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/dream/service/DailyHistoryService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DailyHistoryService.java
@@ -21,11 +21,11 @@ public class DailyHistoryService {
     public DailyHistoryResponse createDailyHistory(Long memberId, DailyHistoryCreateDTO dto) {
         final MileStone mileStone = mileStoneRepository.getReferenceById(dto.getMileStoneId());
 
-        if (!mileStone.getDream().getUser().getId().equals(memberId)) {
+        if (!mileStone.isOwner(memberId)) {
             throw new IllegalArgumentException("권한이 없습니다.");
         }
 
-        final DailyHistory dailyHistory = DailyHistoryCreateDTO.toDailyHistory(dto, mileStone);
+        final DailyHistory dailyHistory = dto.toDailyHistory(mileStone);
         dailyHistoryRepository.save(dailyHistory);
 
         return DailyHistoryResponse.of(dailyHistory);

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.dream.service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.dream.domain.DailyHistory;
 import org.example.kkumdoriland.dream.domain.Dream;
@@ -31,10 +32,8 @@ public class DreamService {
     private final DailyHistoryRepository dailyHistoryRepository;
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public DreamResponse getDream(Long dreamId) {
-        final Dream dream = dreamRepository.getReferenceById(dreamId);
-
-        return DreamResponse.of(dream);
+    public List<DreamResponse> getDream(Long memberId) {
+        return dreamRepository.findDreamsByUserId(memberId).stream().map(DreamResponse::of).toList();
     }
 
     @Transactional

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -1,6 +1,7 @@
 package org.example.kkumdoriland.dream.service;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.dream.domain.Dream;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
@@ -18,15 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class DreamService {
     private final DreamRepository dreamRepository;
     private final MemberRepository memberRepository;
+    private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Transactional
     public DreamResponse createDream(Long memberId, DreamCreateDTO dto) {
         final Member member = memberRepository.findMemberById(memberId).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
         final Dream dream = Dream.builder()
             .user(member)
             .title(dto.getTitle())
             .description(dto.getDescription())
-            .dueDate(LocalDateTime.parse(dto.getDueDate()))
+            .dueDate(LocalDate.parse(dto.getDueDate(), dateFormatter).atStartOfDay())
             .build();
 
         final Dream savedDream = dreamRepository.save(dream);

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -4,15 +4,9 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.example.kkumdoriland.dream.domain.DailyHistory;
 import org.example.kkumdoriland.dream.domain.Dream;
-import org.example.kkumdoriland.dream.domain.MileStone;
-import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
-import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
-import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
-import org.example.kkumdoriland.dream.dto.MileStoneResponse;
 import org.example.kkumdoriland.dream.repository.DailyHistoryRepository;
 import org.example.kkumdoriland.dream.repository.DreamRepository;
 import org.example.kkumdoriland.dream.repository.MileStoneRepository;
@@ -50,37 +44,5 @@ public class DreamService {
         final Dream savedDream = dreamRepository.save(dream);
 
         return DreamResponse.of(savedDream);
-    }
-
-    @Transactional
-    public MileStoneResponse createMilestone(Long memberId, MileStoneCreateDTO dto) {
-        final Dream dream = dreamRepository.getReferenceById(dto.getDreamId());
-
-        if (!dream.getUser().getId().equals(memberId)) {
-            throw new IllegalArgumentException("권한이 없습니다.");
-        }
-
-        final MileStone mileStone = MileStone.builder()
-            .dream(dream)
-            .title(dto.getTitle())
-            .description(dto.getDescription())
-            .totalScoreToEarn(dto.getTotalScoreToEarn())
-            .minimumStepSize(dto.getMinimumStepSize())
-            .build();
-
-        return MileStoneResponse.of(mileStoneRepository.save(mileStone));
-    }
-
-    public DailyHistoryResponse createDailyHistory(Long memberId, DailyHistoryCreateDTO dto) {
-        final MileStone mileStone = mileStoneRepository.getReferenceById(dto.getMileStoneId());
-
-        if (!mileStone.getDream().getUser().getId().equals(memberId)) {
-            throw new IllegalArgumentException("권한이 없습니다.");
-        }
-
-        final DailyHistory dailyHistory = DailyHistoryCreateDTO.toDailyHistory(dto, mileStone);
-        dailyHistoryRepository.save(dailyHistory);
-
-        return DailyHistoryResponse.of(dailyHistory);
     }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -10,13 +10,16 @@ import org.example.kkumdoriland.member.domain.Member;
 import org.example.kkumdoriland.member.repository.MemberRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DreamService {
     private final DreamRepository dreamRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public DreamResponse createDream(Long memberId, DreamCreateDTO dto) {
         final Member member = memberRepository.findMemberById(memberId).orElseThrow(() -> new UsernameNotFoundException("User not found"));
         final Dream dream = Dream.builder()

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -1,0 +1,33 @@
+package org.example.kkumdoriland.dream.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.example.kkumdoriland.dream.domain.Dream;
+import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
+import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.repository.DreamRepository;
+import org.example.kkumdoriland.member.domain.Member;
+import org.example.kkumdoriland.member.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DreamService {
+    private final DreamRepository dreamRepository;
+    private final MemberRepository memberRepository;
+
+    public DreamResponse createDream(Long memberId, DreamCreateDTO dto) {
+        final Member member = memberRepository.findMemberById(memberId).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        final Dream dream = Dream.builder()
+            .user(member)
+            .title(dto.getTitle())
+            .description(dto.getDescription())
+            .dueDate(LocalDateTime.parse(dto.getDueDate()))
+            .build();
+
+        final Dream savedDream = dreamRepository.save(dream);
+
+        return DreamResponse.of(savedDream);
+    }
+}

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -3,12 +3,16 @@ package org.example.kkumdoriland.dream.service;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
+import org.example.kkumdoriland.dream.domain.DailyHistory;
 import org.example.kkumdoriland.dream.domain.Dream;
 import org.example.kkumdoriland.dream.domain.MileStone;
+import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
+import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
 import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
 import org.example.kkumdoriland.dream.dto.MileStoneResponse;
+import org.example.kkumdoriland.dream.repository.DailyHistoryRepository;
 import org.example.kkumdoriland.dream.repository.DreamRepository;
 import org.example.kkumdoriland.dream.repository.MileStoneRepository;
 import org.example.kkumdoriland.member.domain.Member;
@@ -24,6 +28,7 @@ public class DreamService {
     private final DreamRepository dreamRepository;
     private final MemberRepository memberRepository;
     private final MileStoneRepository mileStoneRepository;
+    private final DailyHistoryRepository dailyHistoryRepository;
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     public DreamResponse getDream(Long dreamId) {
@@ -65,5 +70,18 @@ public class DreamService {
             .build();
 
         return MileStoneResponse.of(mileStoneRepository.save(mileStone));
+    }
+
+    public DailyHistoryResponse createDailyHistory(Long memberId, DailyHistoryCreateDTO dto) {
+        final MileStone mileStone = mileStoneRepository.getReferenceById(dto.getMileStoneId());
+
+        if (!mileStone.getDream().getUser().getId().equals(memberId)) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        final DailyHistory dailyHistory = DailyHistoryCreateDTO.toDailyHistory(dto, mileStone);
+        dailyHistoryRepository.save(dailyHistory);
+
+        return DailyHistoryResponse.of(dailyHistory);
     }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/DreamService.java
@@ -4,9 +4,13 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.dream.domain.Dream;
+import org.example.kkumdoriland.dream.domain.MileStone;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
+import org.example.kkumdoriland.dream.dto.MileStoneResponse;
 import org.example.kkumdoriland.dream.repository.DreamRepository;
+import org.example.kkumdoriland.dream.repository.MileStoneRepository;
 import org.example.kkumdoriland.member.domain.Member;
 import org.example.kkumdoriland.member.repository.MemberRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,7 +23,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class DreamService {
     private final DreamRepository dreamRepository;
     private final MemberRepository memberRepository;
+    private final MileStoneRepository mileStoneRepository;
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public DreamResponse getDream(Long dreamId) {
+        final Dream dream = dreamRepository.getReferenceById(dreamId);
+
+        return DreamResponse.of(dream);
+    }
 
     @Transactional
     public DreamResponse createDream(Long memberId, DreamCreateDTO dto) {
@@ -35,5 +46,24 @@ public class DreamService {
         final Dream savedDream = dreamRepository.save(dream);
 
         return DreamResponse.of(savedDream);
+    }
+
+    @Transactional
+    public MileStoneResponse createMilestone(Long memberId, MileStoneCreateDTO dto) {
+        final Dream dream = dreamRepository.getReferenceById(dto.getDreamId());
+
+        if (!dream.getUser().getId().equals(memberId)) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        final MileStone mileStone = MileStone.builder()
+            .dream(dream)
+            .title(dto.getTitle())
+            .description(dto.getDescription())
+            .totalScoreToEarn(dto.getTotalScoreToEarn())
+            .minimumStepSize(dto.getMinimumStepSize())
+            .build();
+
+        return MileStoneResponse.of(mileStoneRepository.save(mileStone));
     }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/service/MileStoneService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/MileStoneService.java
@@ -1,0 +1,40 @@
+package org.example.kkumdoriland.dream.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.kkumdoriland.dream.domain.Dream;
+import org.example.kkumdoriland.dream.domain.MileStone;
+import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
+import org.example.kkumdoriland.dream.dto.MileStoneResponse;
+import org.example.kkumdoriland.dream.repository.DreamRepository;
+import org.example.kkumdoriland.dream.repository.MileStoneRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MileStoneService {
+
+    private final DreamRepository dreamRepository;
+    private final MileStoneRepository mileStoneRepository;
+
+    @Transactional
+    public MileStoneResponse createMilestone(Long memberId, MileStoneCreateDTO dto) {
+        final Dream dream = dreamRepository.getReferenceById(dto.getDreamId());
+
+        if (!dream.getUser().getId().equals(memberId)) {
+            throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        final MileStone mileStone = MileStone.builder()
+            .dream(dream)
+            .title(dto.getTitle())
+            .description(dto.getDescription())
+            .totalScoreToEarn(dto.getTotalScoreToEarn())
+            .minimumStepSize(dto.getMinimumStepSize())
+            .build();
+
+        return MileStoneResponse.of(mileStoneRepository.save(mileStone));
+    }
+
+}

--- a/src/main/java/org/example/kkumdoriland/dream/service/MileStoneService.java
+++ b/src/main/java/org/example/kkumdoriland/dream/service/MileStoneService.java
@@ -7,6 +7,7 @@ import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
 import org.example.kkumdoriland.dream.dto.MileStoneResponse;
 import org.example.kkumdoriland.dream.repository.DreamRepository;
 import org.example.kkumdoriland.dream.repository.MileStoneRepository;
+import org.example.kkumdoriland.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MileStoneService {
 
+    private final MemberRepository memberRepository;
     private final DreamRepository dreamRepository;
     private final MileStoneRepository mileStoneRepository;
 
@@ -22,7 +24,7 @@ public class MileStoneService {
     public MileStoneResponse createMilestone(Long memberId, MileStoneCreateDTO dto) {
         final Dream dream = dreamRepository.getReferenceById(dto.getDreamId());
 
-        if (!dream.getUser().getId().equals(memberId)) {
+        if (!dream.isOwner(memberId)) {
             throw new IllegalArgumentException("권한이 없습니다.");
         }
 

--- a/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
+++ b/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
@@ -4,6 +4,8 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.auth.dto.AuthContext;
+import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
+import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
 import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
@@ -43,5 +45,12 @@ public class DreamController {
         final MileStoneResponse mileStone = dreamService.createMilestone(authContext.getMemberDTO().getId(), dto);
 
         return ResponseEntity.created(URI.create("/dream/milestone" + mileStone.getId())).body(mileStone);
+    }
+
+    @PostMapping("/milestone/dailyHistory")
+    public ResponseEntity<DailyHistoryResponse> createDailyHistory(@AuthenticationPrincipal AuthContext authContext, @Valid @RequestBody DailyHistoryCreateDTO dto) {
+        final DailyHistoryResponse dailyHistory = dreamService.createDailyHistory(authContext.getMemberDTO().getId(), dto);
+
+        return ResponseEntity.created(URI.create("/dream/milestone/dailyHistory" + dailyHistory.getId())).body(dailyHistory);
     }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
+++ b/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.dream.ui;
 
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.auth.dto.AuthContext;
 import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
@@ -15,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,11 +26,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class DreamController {
     public final DreamService dreamService;
 
-    @GetMapping("/{dreamId}")
-    public ResponseEntity<DreamResponse> getDream(@PathVariable Long dreamId) {
-        final DreamResponse dream = dreamService.getDream(dreamId);
-
-        return ResponseEntity.ok(dream);
+    @GetMapping()
+    public ResponseEntity<List<DreamResponse>> getDream(@AuthenticationPrincipal AuthContext authContext) {
+        return ResponseEntity.ok(dreamService.getDream(authContext.getMemberDTO().getId()));
     }
 
     @PostMapping()

--- a/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
+++ b/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
@@ -6,10 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.auth.dto.AuthContext;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
+import org.example.kkumdoriland.dream.dto.MileStoneResponse;
 import org.example.kkumdoriland.dream.service.DreamService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,10 +24,24 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class DreamController {
     public final DreamService dreamService;
 
+    @GetMapping("/{dreamId}")
+    public ResponseEntity<DreamResponse> getDream(@PathVariable Long dreamId) {
+        final DreamResponse dream = dreamService.getDream(dreamId);
+
+        return ResponseEntity.ok(dream);
+    }
+
     @PostMapping()
     public ResponseEntity<DreamResponse> createDream(@AuthenticationPrincipal AuthContext authContext, @Valid @RequestBody DreamCreateDTO dto) {
         final DreamResponse dream = dreamService.createDream(authContext.getMemberDTO().getId(), dto);
 
         return ResponseEntity.created(URI.create("/dream/" + dream.getId())).body(dream);
+    }
+
+    @PostMapping("/milestone")
+    public ResponseEntity<MileStoneResponse> createMilestone(@AuthenticationPrincipal AuthContext authContext, @Valid @RequestBody MileStoneCreateDTO dto) {
+        final MileStoneResponse mileStone = dreamService.createMilestone(authContext.getMemberDTO().getId(), dto);
+
+        return ResponseEntity.created(URI.create("/dream/milestone" + mileStone.getId())).body(mileStone);
     }
 }

--- a/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
+++ b/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
@@ -11,7 +11,9 @@ import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
 import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
 import org.example.kkumdoriland.dream.dto.MileStoneResponse;
+import org.example.kkumdoriland.dream.service.DailyHistoryService;
 import org.example.kkumdoriland.dream.service.DreamService;
+import org.example.kkumdoriland.dream.service.MileStoneService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -25,6 +27,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 public class DreamController {
     public final DreamService dreamService;
+    public final MileStoneService mileStoneService;
+    public final DailyHistoryService dailyHistoryService;
 
     @GetMapping()
     public ResponseEntity<List<DreamResponse>> getDream(@AuthenticationPrincipal AuthContext authContext) {
@@ -40,14 +44,14 @@ public class DreamController {
 
     @PostMapping("/milestone")
     public ResponseEntity<MileStoneResponse> createMilestone(@AuthenticationPrincipal AuthContext authContext, @Valid @RequestBody MileStoneCreateDTO dto) {
-        final MileStoneResponse mileStone = dreamService.createMilestone(authContext.getMemberDTO().getId(), dto);
+        final MileStoneResponse mileStone = mileStoneService.createMilestone(authContext.getMemberDTO().getId(), dto);
 
         return ResponseEntity.created(URI.create("/dream/milestone" + mileStone.getId())).body(mileStone);
     }
 
     @PostMapping("/milestone/dailyHistory")
     public ResponseEntity<DailyHistoryResponse> createDailyHistory(@AuthenticationPrincipal AuthContext authContext, @Valid @RequestBody DailyHistoryCreateDTO dto) {
-        final DailyHistoryResponse dailyHistory = dreamService.createDailyHistory(authContext.getMemberDTO().getId(), dto);
+        final DailyHistoryResponse dailyHistory = dailyHistoryService.createDailyHistory(authContext.getMemberDTO().getId(), dto);
 
         return ResponseEntity.created(URI.create("/dream/milestone/dailyHistory" + dailyHistory.getId())).body(dailyHistory);
     }

--- a/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
+++ b/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
@@ -1,11 +1,12 @@
 package org.example.kkumdoriland.dream.ui;
 
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.example.kkumdoriland.auth.dto.AuthContext;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
 import org.example.kkumdoriland.dream.service.DreamService;
-import org.example.kkumdoriland.member.dto.MemberDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -20,11 +21,9 @@ public class DreamController {
     public final DreamService dreamService;
 
     @PostMapping()
-    public ResponseEntity<DreamResponse> createDream(@AuthenticationPrincipal MemberDTO member, @RequestBody DreamCreateDTO dto) {
-        final DreamResponse dream = dreamService.createDream(member.getId(), dto);
+    public ResponseEntity<DreamResponse> createDream(@AuthenticationPrincipal AuthContext authContext, @Valid @RequestBody DreamCreateDTO dto) {
+        final DreamResponse dream = dreamService.createDream(authContext.getMemberDTO().getId(), dto);
 
         return ResponseEntity.created(URI.create("/dream/" + dream.getId())).body(dream);
     }
-
-
 }

--- a/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
+++ b/src/main/java/org/example/kkumdoriland/dream/ui/DreamController.java
@@ -1,0 +1,30 @@
+package org.example.kkumdoriland.dream.ui;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
+import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.service.DreamService;
+import org.example.kkumdoriland.member.dto.MemberDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/dream")
+@RequiredArgsConstructor
+public class DreamController {
+    public final DreamService dreamService;
+
+    @PostMapping()
+    public ResponseEntity<DreamResponse> createDream(@AuthenticationPrincipal MemberDTO member, @RequestBody DreamCreateDTO dto) {
+        final DreamResponse dream = dreamService.createDream(member.getId(), dto);
+
+        return ResponseEntity.created(URI.create("/dream/" + dream.getId())).body(dream);
+    }
+
+
+}

--- a/src/main/java/org/example/kkumdoriland/feed/domain/Feed.java
+++ b/src/main/java/org/example/kkumdoriland/feed/domain/Feed.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.feed.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,7 +20,7 @@ public class Feed extends BaseEntity {
     @Column(columnDefinition = "json")
     private FeedContents contents;
 
-    @ManyToOne
+    @ManyToOne(fetch= FetchType.LAZY)
     @JoinColumn(name="authorId")
     private Member user;
 }

--- a/src/main/java/org/example/kkumdoriland/member/repository/MemberRepository.java
+++ b/src/main/java/org/example/kkumdoriland/member/repository/MemberRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberByEmail(String email);
+    Optional<Member> findMemberById(Long id);
 }

--- a/src/main/java/org/example/kkumdoriland/member/service/MemberService.java
+++ b/src/main/java/org/example/kkumdoriland/member/service/MemberService.java
@@ -1,4 +1,4 @@
-package org.example.kkumdoriland.member.application;
+package org.example.kkumdoriland.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.kkumdoriland.member.domain.Member;
@@ -18,6 +18,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public MemberResponse join(MemberJoinDTO dto) {
         final Member userToCreate = dto.toMember(passwordEncoder);
 
@@ -26,6 +27,7 @@ public class MemberService {
 
         return MemberResponse.of(memberRepository.save(userToCreate));
     }
+
     private void validateDuplicatedEmail(Member user) {
         if (memberRepository.findMemberByEmail(user.getEmail()).isPresent()) {
             throw new MemberException(MemberErrorCode.USER_EMAIL_DUPLICATION, "이미 존재하는 이메일입니다.");

--- a/src/main/java/org/example/kkumdoriland/member/ui/MemberController.java
+++ b/src/main/java/org/example/kkumdoriland/member/ui/MemberController.java
@@ -1,10 +1,9 @@
 package org.example.kkumdoriland.member.ui;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.example.kkumdoriland.member.application.MemberService;
+import org.example.kkumdoriland.member.service.MemberService;
 import org.example.kkumdoriland.member.dto.MemberJoinDTO;
 import org.example.kkumdoriland.member.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/example/kkumdoriland/notification/domain/Notification.java
+++ b/src/main/java/org/example/kkumdoriland/notification/domain/Notification.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.notification.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,7 +20,7 @@ public class Notification extends BaseEntity {
     @Column(columnDefinition= "json")
     private NotificationContents contents;
 
-    @ManyToOne
+    @ManyToOne(fetch= FetchType.LAZY)
     @JoinColumn(name="userId")
     private Member user;
 }

--- a/src/main/java/org/example/kkumdoriland/request/domain/Request.java
+++ b/src/main/java/org/example/kkumdoriland/request/domain/Request.java
@@ -1,13 +1,14 @@
 package org.example.kkumdoriland.request.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.EnumType;
 import org.example.kkumdoriland.common.domain.BaseEntity;
 import org.example.kkumdoriland.member.domain.Member;
 
@@ -17,11 +18,11 @@ public class Request extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="requesterId")
     private Member requester;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="receiverId")
     private Member receiver;
 

--- a/src/test/java/org/example/kkumdoriland/acceptance/AcceptanceContext.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/AcceptanceContext.java
@@ -4,10 +4,8 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Profile("test")
 @Component
 public class AcceptanceContext {
 

--- a/src/test/java/org/example/kkumdoriland/acceptance/AcceptanceContext.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/AcceptanceContext.java
@@ -10,6 +10,17 @@ import org.springframework.stereotype.Component;
 @Profile("test")
 @Component
 public class AcceptanceContext {
+
+    private static final String TOKEN_POSTFIX = "_token";
+
     public Map<String, Object> store = new HashMap<>();
     public ExtractableResponse<Response> response;
+
+    public void setToken(String userName, String token) {
+        store.put(userName + TOKEN_POSTFIX, token);
+    }
+
+    public String getToken(String userName) {
+        return (String) store.get(userName + TOKEN_POSTFIX);
+    }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/CucumberTest.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/CucumberTest.java
@@ -10,9 +10,7 @@ import org.junit.platform.suite.api.IncludeEngines;
 import org.junit.platform.suite.api.SelectClasspathResource;
 import org.junit.platform.suite.api.Suite;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
 @Suite
 @IncludeEngines("cucumber")
 @SelectClasspathResource("features")

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
@@ -1,71 +1,53 @@
 package org.example.kkumdoriland.acceptance.domains;
 
-import io.restassured.RestAssured;
+import io.restassured.http.Method;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.HashMap;
-import java.util.Map;
-import org.springframework.http.MediaType;
+import java.net.URI;
+import org.example.kkumdoriland.utils.AcceptanceStepBuilder;
 
 public class DreamSteps {
 
     public static ExtractableResponse<Response> 꿈_생성(String cookie, String title, String description, String dueDate) {
-        final Map<String, String> params = new HashMap<>();
-        params.put("title", title);
-        params.put("description", description);
-        params.put("dueDate", dueDate);
-
-        return RestAssured.given().log().all()
+        return AcceptanceStepBuilder.builder()
             .cookie("JSESSIONID", cookie)
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/api/dream")
-            .then().log().all()
-            .extract();
+            .param("title", title)
+            .param("description", description)
+            .param("dueDate", dueDate)
+            .uri(URI.create("/api/dream"))
+            .method(Method.POST)
+            .build();
     }
 
     public static ExtractableResponse<Response> 마일스톤_생성(String cookie, Long dreamId, String title, String description, int totalScoreToEarn, int minimumStepSize) {
-        final Map<String, String> params = new HashMap<>();
-        params.put("title", title);
-        params.put("description", description);
-        params.put("totalScoreToEarn", Integer.toString(totalScoreToEarn));
-        params.put("minimumStepSize", Integer.toString(minimumStepSize));
-        params.put("dreamId", Long.toString(dreamId));
-
-        return RestAssured.given().log().all()
+        return AcceptanceStepBuilder.builder()
             .cookie("JSESSIONID", cookie)
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/api/dream/milestone")
-            .then().log().all()
-            .extract();
+            .param("title", title)
+            .param("description", description)
+            .param("totalScoreToEarn", Integer.toString(totalScoreToEarn))
+            .param("minimumStepSize", Integer.toString(minimumStepSize))
+            .param("dreamId", Long.toString(dreamId))
+            .uri(URI.create("/api/dream/milestone"))
+            .method(Method.POST)
+            .build();
     }
 
     public static ExtractableResponse<Response> 하루기록_생성(String cookie, long milestoneId, String contentText, int stepSize) {
-        final Map<String, String> params = new HashMap<>();
-        params.put("contentText", contentText);
-        params.put("stepSize", Integer.toString(stepSize));
-        params.put("mileStoneId", Long.toString(milestoneId));
-
-        return RestAssured.given().log().all()
+        return AcceptanceStepBuilder.builder()
             .cookie("JSESSIONID", cookie)
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/api/dream/milestone/dailyHistory")
-            .then().log().all()
-            .extract();
+            .param("contentText", contentText)
+            .param("stepSize", Integer.toString(stepSize))
+            .param("mileStoneId", Long.toString(milestoneId))
+            .uri(URI.create("/api/dream/milestone/dailyHistory"))
+            .method(Method.POST)
+            .build();
     }
 
     public static ExtractableResponse<Response> 꿈_조회(String cookie) {
-        return RestAssured.given().log().all()
+        return AcceptanceStepBuilder.builder()
             .cookie("JSESSIONID", cookie)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .get("/api/dream")
-            .then().log().all()
-            .extract();
+            .uri(URI.create("/api/dream"))
+            .method(Method.GET)
+            .build();
     }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
@@ -58,4 +58,17 @@ public class DreamSteps {
             .then().log().all()
             .extract();
     }
+
+    public static ExtractableResponse<Response> 꿈_조회(String cookie) {
+        final Map<String, String> params = new HashMap<>();
+
+        return RestAssured.given().log().all()
+            .cookie("JSESSIONID", cookie)
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/api/dream")
+            .then().log().all()
+            .extract();
+    }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
@@ -42,4 +42,20 @@ public class DreamSteps {
             .then().log().all()
             .extract();
     }
+
+    public static ExtractableResponse<Response> 하루기록_생성(String cookie, long milestoneId, String contentText, int stepSize) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("contentText", contentText);
+        params.put("stepSize", Integer.toString(stepSize));
+        params.put("mileStoneId", Long.toString(milestoneId));
+
+        return RestAssured.given().log().all()
+            .cookie("JSESSIONID", cookie)
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/api/dream/milestone/dailyHistory")
+            .then().log().all()
+            .extract();
+    }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
@@ -1,0 +1,27 @@
+package org.example.kkumdoriland.acceptance.domains;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.MediaType;
+
+public class DreamSteps {
+
+    public static ExtractableResponse<Response> 꿈_생성(String cookie, String title, String description, String dueDate) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("title", title);
+        params.put("description", description);
+        params.put("dueDate", dueDate);
+
+        return RestAssured.given().log().all()
+            .cookie("JSESSIONID", cookie)
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/api/dream")
+            .then().log().all()
+            .extract();
+    }
+}

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
@@ -60,11 +60,8 @@ public class DreamSteps {
     }
 
     public static ExtractableResponse<Response> 꿈_조회(String cookie) {
-        final Map<String, String> params = new HashMap<>();
-
         return RestAssured.given().log().all()
             .cookie("JSESSIONID", cookie)
-            .body(params)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .when()
             .get("/api/dream")

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/DreamSteps.java
@@ -24,4 +24,22 @@ public class DreamSteps {
             .then().log().all()
             .extract();
     }
+
+    public static ExtractableResponse<Response> 마일스톤_생성(String cookie, Long dreamId, String title, String description, int totalScoreToEarn, int minimumStepSize) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("title", title);
+        params.put("description", description);
+        params.put("totalScoreToEarn", Integer.toString(totalScoreToEarn));
+        params.put("minimumStepSize", Integer.toString(minimumStepSize));
+        params.put("dreamId", Long.toString(dreamId));
+
+        return RestAssured.given().log().all()
+            .cookie("JSESSIONID", cookie)
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/api/dream/milestone")
+            .then().log().all()
+            .extract();
+    }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/domains/MemberSteps.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/domains/MemberSteps.java
@@ -1,39 +1,28 @@
 package org.example.kkumdoriland.acceptance.domains;
 
-import io.restassured.RestAssured;
+import io.restassured.http.Method;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.HashMap;
-import java.util.Map;
-import org.springframework.http.MediaType;
+import java.net.URI;
+import org.example.kkumdoriland.utils.AcceptanceStepBuilder;
 
 public class MemberSteps {
     public static ExtractableResponse<Response> 유저_생성(String name, String email, String password) {
-        final Map<String, String> params = new HashMap<>();
-        params.put("name", name);
-        params.put("email", email);
-        params.put("password", password);
-
-        return RestAssured.given().log().all()
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/api/user/join")
-            .then().log().all()
-            .extract();
+        return AcceptanceStepBuilder.builder()
+            .param("name", name)
+            .param("email", email)
+            .param("password", password)
+            .uri(URI.create("/api/user/join"))
+            .method(Method.POST)
+            .build();
     }
 
     public static ExtractableResponse<Response> 유저_로그인(String email, String password) {
-        final Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("password", password);
-
-        return RestAssured.given().log().all()
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/api/user/login")
-            .then().log().all()
-            .extract();
+        return AcceptanceStepBuilder.builder()
+            .param("email", email)
+            .param("password", password)
+            .uri(URI.create("/api/user/login"))
+            .method(Method.POST)
+            .build();
     }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
@@ -1,6 +1,8 @@
 package org.example.kkumdoriland.acceptance.steps;
 
 import static org.example.kkumdoriland.acceptance.domains.DreamSteps.꿈_생성;
+import static org.example.kkumdoriland.acceptance.domains.DreamSteps.마일스톤_생성;
+import static org.example.kkumdoriland.utils.ResponseUtils.응답에서_id_조회;
 import static org.example.kkumdoriland.utils.ResponseUtils.응답의_STATUS_검증;
 
 import io.cucumber.java8.En;
@@ -14,11 +16,23 @@ public class DreamStepDef implements En {
     private AcceptanceContext context;
 
     public DreamStepDef() {
-        When("유저는 {string}, {string}, {string}을 이용해 꿈을 생성한다.", (String title, String description, String dueDate) -> {
-            context.response = 꿈_생성(context.response.cookie("JSESSIONID"), title, description, dueDate);
+        When("{string} 유저는 {string}, {string}, {string}을 이용해 꿈을 생성한다.", (String userName, String title, String description, String dueDate) -> {
+            context.response = 꿈_생성(context.getToken(userName), title, description, dueDate);
+        });
+
+        When("{string} 유저는 {string}, {string}, {string}을 이용해 마일스톤을 생성한다.", (String userName, String dreamTitle, String title, String description) -> {
+            context.response = 마일스톤_생성(
+                context.getToken(userName),
+                응답에서_id_조회(context.response),
+                title, description, 10, 10
+            );
         });
 
         Then("유저는 꿈을 생성에 성공한다.", () -> {
+            응답의_STATUS_검증(context.response, HttpStatus.CREATED);
+        });
+
+        Then("유저는 마일스톤을 생성에 성공한다.", () -> {
             응답의_STATUS_검증(context.response, HttpStatus.CREATED);
         });
     }

--- a/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
@@ -1,22 +1,43 @@
 package org.example.kkumdoriland.acceptance.steps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.example.kkumdoriland.acceptance.domains.DreamSteps.꿈_생성;
+import static org.example.kkumdoriland.acceptance.domains.DreamSteps.꿈_조회;
 import static org.example.kkumdoriland.acceptance.domains.DreamSteps.마일스톤_생성;
 import static org.example.kkumdoriland.acceptance.domains.DreamSteps.하루기록_생성;
 import static org.example.kkumdoriland.utils.ResponseUtils.응답에서_id_조회;
 import static org.example.kkumdoriland.utils.ResponseUtils.응답의_STATUS_검증;
 
+import io.cucumber.datatable.DataTable;
 import io.cucumber.java8.En;
+import java.util.List;
+import java.util.Map;
 import org.example.kkumdoriland.acceptance.AcceptanceContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 public class DreamStepDef implements En {
 
+    private static final String DREAM_POSTFIX = "_dream";
+
     @Autowired
     private AcceptanceContext context;
 
     public DreamStepDef() {
+        Given("유저는 꿈을 생성한다.", (DataTable tables) -> {
+            List<Map<String, String>> maps = tables.asMaps();
+
+            maps.forEach(it -> saveDream(
+                it.get("name"),
+                응답에서_id_조회(꿈_생성(
+                    context.getToken(it.get("userName")),
+                    it.get("title"),
+                    it.get("description"),
+                    it.get("dueDate")
+                ))
+            ));
+        });
+
         When("{string} 유저는 {string}, {string}, {string}을 이용해 꿈을 생성한다.", (String userName, String title, String description, String dueDate) -> {
             context.response = 꿈_생성(context.getToken(userName), title, description, dueDate);
         });
@@ -38,6 +59,10 @@ public class DreamStepDef implements En {
             );
         });
 
+        When("{string} 유저는 자신의 꿈을 조회한다.", (String userName) -> {
+            context.response = 꿈_조회(context.getToken(userName));
+        });
+
         Then("유저는 꿈을 생성에 성공한다.", () -> {
             응답의_STATUS_검증(context.response, HttpStatus.CREATED);
         });
@@ -50,5 +75,17 @@ public class DreamStepDef implements En {
             응답의_STATUS_검증(context.response, HttpStatus.CREATED);
         });
 
+        Then("{int}개 꿈이 조회 된다.", (Integer numberOfDreams) -> {
+            assertThat(context.response.jsonPath().getList("").size()).isEqualTo(3);
+        });
     }
+
+    public void saveDream(String name, Long id) {
+        context.store.put(name + DREAM_POSTFIX, id);
+    }
+
+    public Long getDream(String name) {
+        return (Long) context.store.get(name + DREAM_POSTFIX);
+    }
+
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
@@ -1,0 +1,25 @@
+package org.example.kkumdoriland.acceptance.steps;
+
+import static org.example.kkumdoriland.acceptance.domains.DreamSteps.꿈_생성;
+import static org.example.kkumdoriland.utils.ResponseUtils.응답의_STATUS_검증;
+
+import io.cucumber.java8.En;
+import org.example.kkumdoriland.acceptance.AcceptanceContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class DreamStepDef implements En {
+
+    @Autowired
+    private AcceptanceContext context;
+
+    public DreamStepDef() {
+        When("유저는 {string}, {string}, {string}을 이용해 꿈을 생성한다.", (String title, String description, String dueDate) -> {
+            context.response = 꿈_생성(context.response.cookie("JSESSIONID"), title, description, dueDate);
+        });
+
+        Then("유저는 꿈을 생성에 성공한다.", () -> {
+            응답의_STATUS_검증(context.response, HttpStatus.CREATED);
+        });
+    }
+}

--- a/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
@@ -76,7 +76,7 @@ public class DreamStepDef implements En {
         });
 
         Then("{int}개 꿈이 조회 된다.", (Integer numberOfDreams) -> {
-            assertThat(context.response.jsonPath().getList("").size()).isEqualTo(3);
+            assertThat(context.response.jsonPath().getList(".").size()).isEqualTo(3);
         });
     }
 

--- a/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/steps/DreamStepDef.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.acceptance.steps;
 
 import static org.example.kkumdoriland.acceptance.domains.DreamSteps.꿈_생성;
 import static org.example.kkumdoriland.acceptance.domains.DreamSteps.마일스톤_생성;
+import static org.example.kkumdoriland.acceptance.domains.DreamSteps.하루기록_생성;
 import static org.example.kkumdoriland.utils.ResponseUtils.응답에서_id_조회;
 import static org.example.kkumdoriland.utils.ResponseUtils.응답의_STATUS_검증;
 
@@ -28,6 +29,15 @@ public class DreamStepDef implements En {
             );
         });
 
+        When("{string} 유저는 {string}, {int}을 이용해 하루기록을 생성한다.", (String userName, String contentText, Integer stepSize) -> {
+            context.response = 하루기록_생성(
+                context.getToken(userName),
+                응답에서_id_조회(context.response),
+                contentText,
+                stepSize
+            );
+        });
+
         Then("유저는 꿈을 생성에 성공한다.", () -> {
             응답의_STATUS_검증(context.response, HttpStatus.CREATED);
         });
@@ -35,5 +45,10 @@ public class DreamStepDef implements En {
         Then("유저는 마일스톤을 생성에 성공한다.", () -> {
             응답의_STATUS_검증(context.response, HttpStatus.CREATED);
         });
+
+        Then("유저는 하루기록을 생성에 성공한다.", () -> {
+            응답의_STATUS_검증(context.response, HttpStatus.CREATED);
+        });
+
     }
 }

--- a/src/test/java/org/example/kkumdoriland/acceptance/steps/MemberStepDef.java
+++ b/src/test/java/org/example/kkumdoriland/acceptance/steps/MemberStepDef.java
@@ -29,6 +29,15 @@ public class MemberStepDef implements En {
             ));
         });
 
+        Given("^유저로 로그인한다.", (DataTable table) -> {
+            List<Map<String, String>> maps = table.asMaps();
+
+            maps.forEach(it -> context.setToken(
+                it.get("name"),
+                유저_로그인(it.get("email"), it.get("password")).cookie("JSESSIONID")
+            ));
+        });
+
         When("유저는 {string}, {string}, {string}을 이용해 회원가입한다.", (String name, String email, String password) -> {
            context.response = 유저_생성(name, email, password);
         });

--- a/src/test/java/org/example/kkumdoriland/integration/DailyHistoryServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/DailyHistoryServiceTest.java
@@ -2,10 +2,15 @@ package org.example.kkumdoriland.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
+import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
+import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
+import org.example.kkumdoriland.dream.dto.MileStoneResponse;
+import org.example.kkumdoriland.dream.service.DailyHistoryService;
 import org.example.kkumdoriland.dream.service.DreamService;
+import org.example.kkumdoriland.dream.service.MileStoneService;
 import org.example.kkumdoriland.member.dto.MemberJoinDTO;
 import org.example.kkumdoriland.member.dto.MemberResponse;
 import org.example.kkumdoriland.member.service.MemberService;
@@ -13,9 +18,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DreamServiceTest extends IntegrationTestBase {
+public class DailyHistoryServiceTest extends IntegrationTestBase {
     @Autowired
     private DreamService dreamService;
+    @Autowired
+    private MileStoneService mileStoneService;
+    @Autowired
+    private DailyHistoryService dailyHistoryService;
+
     @Autowired
     private MemberService memberService;
 
@@ -32,42 +42,17 @@ public class DreamServiceTest extends IntegrationTestBase {
     }
 
     @Test
-    void 꿈_생성() {
-        // given
-        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
-
-        // when
-        final DreamResponse dream = dreamService.createDream(memberId, dto);
-
-        // then
-        assertThat(dream).isNotNull();
-    }
-
-    @Test
-    void 꿈_조회() {
+    void 하루기록_생성() {
         // given
         final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
         final DreamResponse dream = dreamService.createDream(memberId, dto);
+        final MileStoneCreateDTO milestoneDto = new MileStoneCreateDTO(dream.getId(), "title", "description", 10, 10);
+        final MileStoneResponse milestone = mileStoneService.createMilestone(memberId, milestoneDto);
 
         // when
-        final List<DreamResponse> foundDream = dreamService.getDream(memberId);
+        final DailyHistoryResponse createdStep = dailyHistoryService.createDailyHistory(memberId, new DailyHistoryCreateDTO("content", 10, milestone.getId()));
 
         // then
-        assertThat(foundDream).isNotNull();
-        assertThat(foundDream.stream().map(DreamResponse::getId)).contains(dream.getId());
-    }
-
-    @Test
-    void 꿈_조회__다양한_쿼리() {
-        // given
-        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
-        final DreamResponse dream = dreamService.createDream(memberId, dto);
-
-        // when
-        final List<DreamResponse> foundDream = dreamService.getDream(memberId);
-
-        // then
-        assertThat(foundDream).isNotNull();
-        assertThat(foundDream.stream().map(DreamResponse::getId)).contains(dream.getId());
+        assertThat(createdStep).isNotNull();
     }
 }

--- a/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
+import org.example.kkumdoriland.dream.dto.MileStoneResponse;
 import org.example.kkumdoriland.dream.service.DreamService;
-import org.example.kkumdoriland.member.service.MemberService;
 import org.example.kkumdoriland.member.dto.MemberJoinDTO;
 import org.example.kkumdoriland.member.dto.MemberResponse;
+import org.example.kkumdoriland.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,12 +35,39 @@ public class DreamServiceTest extends IntegrationTestBase {
     @Test
     void 꿈_생성() {
         // given
-        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31T00:00:00");
+        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
 
         // when
         final DreamResponse dream = dreamService.createDream(memberId, dto);
 
         // then
         assertThat(dream).isNotNull();
+    }
+
+    @Test
+    void 꿈_조회() {
+        // given
+        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
+        final DreamResponse dream = dreamService.createDream(memberId, dto);
+
+        // when
+        final DreamResponse foundDream = dreamService.getDream(dream.getId());
+
+        // then
+        assertThat(foundDream).isNotNull();
+    }
+
+    @Test
+    void 마일스톤_생성() {
+        // given
+        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
+        final DreamResponse dream = dreamService.createDream(memberId, dto);
+        final MileStoneCreateDTO milestoneDto = new MileStoneCreateDTO(dream.getId(), "title", "description", 10, 10);
+
+        // when
+        final MileStoneResponse milestone = dreamService.createMilestone(memberId, milestoneDto);
+
+        // then
+        assertThat(milestone).isNotNull();
     }
 }

--- a/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
@@ -1,0 +1,44 @@
+package org.example.kkumdoriland.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
+import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.service.DreamService;
+import org.example.kkumdoriland.member.application.MemberService;
+import org.example.kkumdoriland.member.dto.MemberJoinDTO;
+import org.example.kkumdoriland.member.dto.MemberResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DreamServiceTest extends IntegrationTestBase {
+    @Autowired
+    private DreamService dreamService;
+    @Autowired
+    private MemberService memberService;
+
+    private final String email = "email@a.b";
+    private final String password = "password";
+    private final String name = "name";
+
+    private Long memberId;
+
+    @BeforeEach
+    void memberSetup() {
+        final MemberResponse response = memberService.join(new MemberJoinDTO(email, password, name));
+        memberId = response.getId();
+    }
+
+    @Test
+    void 꿈_생성() {
+        // given
+        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31T00:00:00");
+
+        // when
+        final DreamResponse dream = dreamService.createDream(memberId, dto);
+
+        // then
+        assertThat(dream).isNotNull();
+    }
+}

--- a/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
@@ -2,6 +2,7 @@ package org.example.kkumdoriland.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
 import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
@@ -53,10 +54,11 @@ public class DreamServiceTest extends IntegrationTestBase {
         final DreamResponse dream = dreamService.createDream(memberId, dto);
 
         // when
-        final DreamResponse foundDream = dreamService.getDream(dream.getId());
+        final List<DreamResponse> foundDream = dreamService.getDream(memberId);
 
         // then
         assertThat(foundDream).isNotNull();
+        assertThat(foundDream.stream().map(DreamResponse::getId)).contains(dream.getId());
     }
 
     @Test

--- a/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
 import org.example.kkumdoriland.dream.service.DreamService;
-import org.example.kkumdoriland.member.application.MemberService;
+import org.example.kkumdoriland.member.service.MemberService;
 import org.example.kkumdoriland.member.dto.MemberJoinDTO;
 import org.example.kkumdoriland.member.dto.MemberResponse;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/DreamServiceTest.java
@@ -2,6 +2,8 @@ package org.example.kkumdoriland.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.example.kkumdoriland.dream.dto.DailyHistoryCreateDTO;
+import org.example.kkumdoriland.dream.dto.DailyHistoryResponse;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
 import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
@@ -69,5 +71,20 @@ public class DreamServiceTest extends IntegrationTestBase {
 
         // then
         assertThat(milestone).isNotNull();
+    }
+
+    @Test
+    void 하루기록_생성() {
+        // given
+        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
+        final DreamResponse dream = dreamService.createDream(memberId, dto);
+        final MileStoneCreateDTO milestoneDto = new MileStoneCreateDTO(dream.getId(), "title", "description", 10, 10);
+        final MileStoneResponse milestone = dreamService.createMilestone(memberId, milestoneDto);
+
+        // when
+        final DailyHistoryResponse createdStep = dreamService.createDailyHistory(memberId, new DailyHistoryCreateDTO("content", 10, milestone.getId()));
+
+        // then
+        assertThat(createdStep).isNotNull();
     }
 }

--- a/src/test/java/org/example/kkumdoriland/integration/IntegrationTestBase.java
+++ b/src/test/java/org/example/kkumdoriland/integration/IntegrationTestBase.java
@@ -4,9 +4,7 @@ import org.example.kkumdoriland.utils.DatabaseCleanup;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class IntegrationTestBase {
      @Autowired

--- a/src/test/java/org/example/kkumdoriland/integration/MemberServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/MemberServiceTest.java
@@ -4,7 +4,7 @@ package org.example.kkumdoriland.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.example.kkumdoriland.member.application.MemberService;
+import org.example.kkumdoriland.member.service.MemberService;
 import org.example.kkumdoriland.member.dto.MemberJoinDTO;
 import org.example.kkumdoriland.member.dto.MemberResponse;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/example/kkumdoriland/integration/MileStoneServiceTest.java
+++ b/src/test/java/org/example/kkumdoriland/integration/MileStoneServiceTest.java
@@ -2,10 +2,12 @@ package org.example.kkumdoriland.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import org.example.kkumdoriland.dream.dto.DreamCreateDTO;
 import org.example.kkumdoriland.dream.dto.DreamResponse;
+import org.example.kkumdoriland.dream.dto.MileStoneCreateDTO;
+import org.example.kkumdoriland.dream.dto.MileStoneResponse;
 import org.example.kkumdoriland.dream.service.DreamService;
+import org.example.kkumdoriland.dream.service.MileStoneService;
 import org.example.kkumdoriland.member.dto.MemberJoinDTO;
 import org.example.kkumdoriland.member.dto.MemberResponse;
 import org.example.kkumdoriland.member.service.MemberService;
@@ -13,9 +15,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DreamServiceTest extends IntegrationTestBase {
+public class MileStoneServiceTest extends IntegrationTestBase {
     @Autowired
     private DreamService dreamService;
+    @Autowired
+    private MileStoneService mileStoneService;
     @Autowired
     private MemberService memberService;
 
@@ -31,43 +35,20 @@ public class DreamServiceTest extends IntegrationTestBase {
         memberId = response.getId();
     }
 
-    @Test
-    void 꿈_생성() {
-        // given
-        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
-
-        // when
-        final DreamResponse dream = dreamService.createDream(memberId, dto);
-
-        // then
-        assertThat(dream).isNotNull();
-    }
 
     @Test
-    void 꿈_조회() {
+    void 마일스톤_생성() {
         // given
         final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
         final DreamResponse dream = dreamService.createDream(memberId, dto);
+        final MileStoneCreateDTO milestoneDto = new MileStoneCreateDTO(dream.getId(), "title", "description", 10, 10);
 
         // when
-        final List<DreamResponse> foundDream = dreamService.getDream(memberId);
+        final MileStoneResponse milestone = mileStoneService.createMilestone(memberId, milestoneDto);
 
         // then
-        assertThat(foundDream).isNotNull();
-        assertThat(foundDream.stream().map(DreamResponse::getId)).contains(dream.getId());
+        assertThat(milestone).isNotNull();
     }
 
-    @Test
-    void 꿈_조회__다양한_쿼리() {
-        // given
-        final DreamCreateDTO dto = new DreamCreateDTO("title", "description", "2022-12-31");
-        final DreamResponse dream = dreamService.createDream(memberId, dto);
 
-        // when
-        final List<DreamResponse> foundDream = dreamService.getDream(memberId);
-
-        // then
-        assertThat(foundDream).isNotNull();
-        assertThat(foundDream.stream().map(DreamResponse::getId)).contains(dream.getId());
-    }
 }

--- a/src/test/java/org/example/kkumdoriland/utils/AcceptanceStepBuilder.java
+++ b/src/test/java/org/example/kkumdoriland/utils/AcceptanceStepBuilder.java
@@ -1,0 +1,78 @@
+package org.example.kkumdoriland.utils;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Method;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.util.Assert;
+
+public class AcceptanceStepBuilder {
+    private Map<String, String> params = new HashMap<>();
+    private Map<String, String> cookies = new HashMap<>();
+    private MediaType contentType = MediaType.APPLICATION_JSON;
+    private Method method;
+    private URI uri;
+
+    private AcceptanceStepBuilder() {
+    }
+
+    public AcceptanceStepBuilder param(String key, String value) {
+        params.put(key, value);
+        return this;
+    }
+
+    public AcceptanceStepBuilder cookie(String key, String value) {
+        cookies.put(key, value);
+        return this;
+    }
+
+    public AcceptanceStepBuilder contentType(MediaType contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public AcceptanceStepBuilder method(Method method) {
+        this.method = method;
+        return this;
+    }
+
+    public AcceptanceStepBuilder uri(URI uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public static AcceptanceStepBuilder builder() {
+        return new AcceptanceStepBuilder();
+    }
+
+    public ExtractableResponse<Response> build() {
+        Assert.notNull(method, "method must not be null");
+        Assert.notNull(uri, "uri must not be null");
+
+        if(method == Method.GET) {
+            return RestAssured
+                .given().log().all()
+                    .params(params)
+                    .cookies(cookies)
+                    .contentType(contentType.toString())
+                .when()
+                    .get(uri)
+                .then().log().all()
+                .extract();
+        }
+
+        return RestAssured
+            .given().log().all()
+                .body(params)
+                .cookies(cookies)
+                .contentType(contentType.toString())
+            .when()
+                .request(method, uri)
+            .then().log().all()
+            .extract();
+    }
+}

--- a/src/test/java/org/example/kkumdoriland/utils/DatabaseCleanup.java
+++ b/src/test/java/org/example/kkumdoriland/utils/DatabaseCleanup.java
@@ -4,16 +4,13 @@ import com.google.common.base.CaseFormat;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.Table;
 import jakarta.persistence.metamodel.EntityType;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Profile("test")
 @Service
 public class DatabaseCleanup implements InitializingBean {
     @PersistenceContext

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,2 +1,0 @@
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: test
   jpa:
     properties:
       hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+#        show_sql: true
+        format_sql: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug

--- a/src/test/resources/features/dream.feature
+++ b/src/test/resources/features/dream.feature
@@ -9,7 +9,7 @@ Feature: 꿈 관련 기능
       | name | email | password |
       | test1 | test1@admin.com | 1234 |
 
-  Scenario: 유저는 꿈을 생성한다.
+  Scenario: 유저는 꿈, 마일스톤, 하루기록을 생성한다.
     When "test1" 유저는 "test1", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
     Then 유저는 꿈을 생성에 성공한다.
 
@@ -17,3 +17,9 @@ Feature: 꿈 관련 기능
     When "test1" 유저는 "test2", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
     When "test1" 유저는 "test2", "milestone1", "milestoneDescription1"을 이용해 마일스톤을 생성한다.
     Then 유저는 마일스톤을 생성에 성공한다.
+
+  Scenario: 유저는 하루기록을 생성한다.
+    When "test1" 유저는 "test2", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
+    When "test1" 유저는 "test2", "milestone1", "milestoneDescription1"을 이용해 마일스톤을 생성한다.
+    When "test1" 유저는 "dailyContentText", 10을 이용해 하루기록을 생성한다.
+    Then 유저는 하루기록을 생성에 성공한다.

--- a/src/test/resources/features/dream.feature
+++ b/src/test/resources/features/dream.feature
@@ -8,6 +8,11 @@ Feature: 꿈 관련 기능
     Given 유저로 로그인한다.
       | name | email | password |
       | test1 | test1@admin.com | 1234 |
+    Given 유저는 꿈을 생성한다.
+      | userName | title |description | dueDate |
+      | test1 | test1 | descriptionForTest1 | 2021-01-01 |
+      | test1 | test2 | descriptionForTest2 | 2021-01-01 |
+      | test1 | test3 | descriptionForTest3 | 2021-01-01 |
 
   Scenario: 유저는 꿈, 마일스톤, 하루기록을 생성한다.
     When "test1" 유저는 "test1", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
@@ -23,3 +28,7 @@ Feature: 꿈 관련 기능
     When "test1" 유저는 "test2", "milestone1", "milestoneDescription1"을 이용해 마일스톤을 생성한다.
     When "test1" 유저는 "dailyContentText", 10을 이용해 하루기록을 생성한다.
     Then 유저는 하루기록을 생성에 성공한다.
+
+  Scenario: 유저는 자신의 꿈을 조회할 수 있다.
+    When "test1" 유저는 자신의 꿈을 조회한다.
+    Then 3개 꿈이 조회 된다.

--- a/src/test/resources/features/dream.feature
+++ b/src/test/resources/features/dream.feature
@@ -5,8 +5,15 @@ Feature: 꿈 관련 기능
       | test1 | test1@admin.com | 1234 |
       | test2 | test2@admin.com | 1234 |
       | test3 | test3@admin.com | 1234 |
+    Given 유저로 로그인한다.
+      | name | email | password |
+      | test1 | test1@admin.com | 1234 |
 
-  Scenario: 유저는 꿈, 마일스톤, 을 생성한다.
-    When 유저는 "test1@admin.com", "1234"을 이용해 로그인한다.
-    When 유저는 "test1", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
+  Scenario: 유저는 꿈을 생성한다.
+    When "test1" 유저는 "test1", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
     Then 유저는 꿈을 생성에 성공한다.
+
+  Scenario: 유저는 마일스톤을 생성한다.
+    When "test1" 유저는 "test2", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
+    When "test1" 유저는 "test2", "milestone1", "milestoneDescription1"을 이용해 마일스톤을 생성한다.
+    Then 유저는 마일스톤을 생성에 성공한다.

--- a/src/test/resources/features/dream.feature
+++ b/src/test/resources/features/dream.feature
@@ -1,0 +1,12 @@
+Feature: 꿈 관련 기능
+  Background:
+    Given 유저 정보를 생성하고
+      | name | email | password |
+      | test1 | test1@admin.com | 1234 |
+      | test2 | test2@admin.com | 1234 |
+      | test3 | test3@admin.com | 1234 |
+
+  Scenario: 유저는 꿈, 마일스톤, 을 생성한다.
+    When 유저는 "test1@admin.com", "1234"을 이용해 로그인한다.
+    When 유저는 "test1", "descriptionForTest1", "2021-01-01"을 이용해 꿈을 생성한다.
+    Then 유저는 꿈을 생성에 성공한다.

--- a/src/test/resources/features/login.feature
+++ b/src/test/resources/features/login.feature
@@ -14,10 +14,9 @@ Feature: 유저 관련 기능
       When 유저는 "test1", "test1@admin.com", "1234"을 이용해 회원가입한다.
       Then 유저는 회원가입에 409으로 실패한다.
 
-#    TODO: 추후 401로 인증 여부 판단을 테스트하도록 진행한다.
     Scenario: 유저는 로그인에 실패한다.
       When 유저는 "test3@admin.com", "12345"을 이용해 로그인한다.
-      Then 유저는 로그인에 403로 실패한다.
+      Then 유저는 로그인에 401로 실패한다.
 
     Scenario: 유저는 로그인에 성공한다.
       When 유저는 "test1@admin.com", "1234"을 이용해 로그인한다.


### PR DESCRIPTION
### 작업 내용
- 생성 관련 테스트 및 기능 추가

### PR 사유
- 조회관련 기능을 넣을때 query dsl을 넣으려고 하는데, 학습이 필요하여 PR을 자름

### 걸리는 점
- create validation할 때 user 정보를 불러오기위해 최대 2번 조회하는 부분이 있는데, 이를 JPQL가지고 해결할지, queryDSL 도입 후 변경할지 고민